### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/luisariass/crawler_foursquare/security/code-scanning/1](https://github.com/luisariass/crawler_foursquare/security/code-scanning/1)

To fix this issue, we need to explicitly declare the permissions required by the workflow or job. The best way is to add a `permissions:` block at the top level of the workflow (before `jobs:`) or within each job. Since the workflow only reads the source code, the minimal permission required is `contents: read`. To implement this, add the following block after the workflow `name` and before `on:`. This ensures that only read access to repository contents is granted for the GITHUB_TOKEN throughout the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
